### PR TITLE
Add ignore new lines on concatenation spacing

### DIFF
--- a/Standards/Pimcore5/ruleset.xml
+++ b/Standards/Pimcore5/ruleset.xml
@@ -7,12 +7,14 @@
 -->
 <ruleset name="Pimcore_PhpCs">
     <description>Pimcore5 PHP CS Standards from Divante.</description>
-    
+
     <rule ref="PSR2" />
 
     <rule ref="Squiz.Strings.ConcatenationSpacing">
-      <properties>
-        <property name="spacing" value="1" />
-      </properties>
+        <properties>
+            <property name="spacing" value="1" />
+            <property name="ignoreNewlines" value="true" />
+        </properties>
     </rule>
 </ruleset>
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

PSR rules should ignore missing concatenation when there's a new line after.

## Changes
### Added
- rule `ignoreNewlines` to psr2

## Example
```
 127 | ERROR | [x] Concat operator must be surrounded by a single space
     |       |     (Squiz.Strings.ConcatenationSpacing.PaddingFound)
```
even though there was a space in the concatenation.

## Tests
After adding the rule, the was no more errors. Removed some spaces from the concatenations to check the errors - there was the error.